### PR TITLE
fix(router): fix property does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/sinon": "^1.16.33",
     "northbrook": "^4.1.5",
     "sinon": "^1.17.6",
+    "ts-node": "1.7.2",
     "tslint": "^4.2.0",
     "typescript": "^2.1.4",
     "yarn": "^0.18.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,13 +1080,13 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-inherits@2.0.1:
+inherits@2, inherits@2.0.1, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
@@ -1371,11 +1371,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.2.0, lodash@^4.3.0:
-  version "4.17.3"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.3.tgz#557ed7d2a9438cac5fd5a43043ca60cb455e01f7"
-
-lodash@~4.13.x:
+lodash@^4.2.0, lodash@^4.3.0, lodash@~4.13.x:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
 
@@ -2074,7 +2070,7 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-ts-node@^1.7.2:
+ts-node@1.7.2, ts-node@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-1.7.2.tgz#d67bbc5c48fde16c244debbfe81b020587369a02"
   dependencies:


### PR DESCRIPTION
- [ ] I added new tests for the issue I fixed or the feature I built
- [x] I ran `npm test` for the package I'm modifying
- [ ] I used `npm run commit` instead of `git commit`

ts-node >1.7.2 has a breaking change that causes typescript
to error property does not exist. Locking to v1.7.2 fixes the error.

AFFECTS: @motorcycle/router