### PR TITLE
fix(i18n): use @typed/i18next

### DIFF
--- a/i18n/package.json
+++ b/i18n/package.json
@@ -24,14 +24,11 @@
   },
   "homepage": "https://github.com/motorcyclejs/motorcyclejs#readme",
   "dependencies": {
-    "i18next": "^4.1.4",
+    "@typed/i18next": "^1.0.0",
     "most": "^1.1.1",
     "most-subject": "^5.3.0"
   },
   "devDependencies": {
-    "@types/i18next": "^2.3.34",
-    "@types/i18next-xhr-backend": "^1.2.2",
-    "i18next-node-fs-backend": "^0.1.3",
-    "i18next-xhr-backend": "^1.2.1"
+    "i18next-node-fs-backend": "^0.1.3"
   }
 }

--- a/i18n/src/makeI18nDriver.ts
+++ b/i18n/src/makeI18nDriver.ts
@@ -1,23 +1,28 @@
-import * as i18next from 'i18next';
-
+import {
+  I18n,
+  Options,
+  TranslationFunction,
+  TranslationOptions,
+  i18n,
+} from '@typed/i18next';
 import { Stream, map } from 'most';
 
 import { sync } from 'most-subject';
 
 export type I18nSource =
-  (key: string, translationOptions?: i18next.TranslationOptions) => Stream<string>;
+  (key: string, translationOptions?: TranslationOptions) => Stream<string>;
 
-export function makeI18nDriver(plugins: Array<any> = [], options?: i18next.Options) {
+export function makeI18nDriver(plugins: Array<any> = [], options?: Options) {
 
   return function i18nDriver(sink$: Stream<string>): I18nSource {
 
-    const translationFn$ = sync<i18next.TranslationFunction>();
+    const translationFn$ = sync<TranslationFunction>();
 
     plugins
-      .reduce((i18n, plugin) => i18n.use(plugin), i18next)
+      .reduce((i18next: I18n, plugin: any) => i18next.use(plugin), i18n)
       .init(options, function () {
         sink$.observe((language: string) => {
-          i18next.changeLanguage(language, function (err: any, t: i18next.TranslationFunction) {
+          i18n.changeLanguage(language, function (err: any, t: TranslationFunction) {
             if (err)
               return translationFn$.error(err);
 
@@ -26,7 +31,7 @@ export function makeI18nDriver(plugins: Array<any> = [], options?: i18next.Optio
         });
       });
 
-    return function i18nSource(key: string, translationOptions?: i18next.TranslationOptions) {
+    return function i18nSource(key: string, translationOptions?: TranslationOptions) {
       return map(t => t(key, translationOptions), translationFn$);
     };
   };

--- a/i18n/yarn.lock
+++ b/i18n/yarn.lock
@@ -12,13 +12,11 @@
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.4.1.tgz#b940b5563096f27637401618a5351f42466ea8f3"
 
-"@types/i18next-xhr-backend@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/i18next-xhr-backend/-/i18next-xhr-backend-1.2.2.tgz#761a2730b4f7e4dde3be96e8efe6ac9df362abcf"
-
-"@types/i18next@^2.3.34":
-  version "2.3.34"
-  resolved "https://registry.yarnpkg.com/@types/i18next/-/i18next-2.3.34.tgz#8abf5c7d0a030085f2d542b6ffaa015c6eee345e"
+"@typed/i18next@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@typed/i18next/-/i18next-1.0.0.tgz#abec1b78a2b05e5b046a45413ad4738b45101fb3"
+  dependencies:
+    i18next "^4.1.4"
 
 argparse@^1.0.2:
   version "1.0.9"
@@ -36,10 +34,6 @@ i18next-node-fs-backend@^0.1.3:
   dependencies:
     js-yaml "3.5.4"
     json5 "0.5.0"
-
-i18next-xhr-backend@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-1.2.1.tgz#33cd9d8d6192f81c1074b45fe440f370f5cf0395"
 
 i18next@^4.1.4:
   version "4.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,8 +84,8 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.35.tgz#dd3150b62a6de73368109308515c3aa86f81f1ec"
 
 "@types/node@*", "@types/node@^6.0.52":
-  version "6.0.56"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.56.tgz#12bc7fff825e72807f55dcbce17e9db6177713dd"
+  version "6.0.57"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.57.tgz#100f9d4390331297bc3b6160ac4805b46de6e752"
 
 "@types/ramda@0.0.2":
   version "0.0.2"
@@ -291,6 +291,12 @@ assert-plus@^0.2.0:
 assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+
+assert@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  dependencies:
+    util "0.10.3"
 
 assert@~1.3.0:
   version "1.3.0"
@@ -683,11 +689,11 @@ browserify-zlib@~0.1.2:
     pako "~0.2.0"
 
 browserify@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/browserify/-/browserify-13.1.1.tgz#72a2310e2f706ed87db929cf0ee73a5e195d9bb0"
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/browserify/-/browserify-13.3.0.tgz#b5a9c9020243f0c70e4675bec8223bc627e415ce"
   dependencies:
     JSONStream "^1.0.3"
-    assert "~1.3.0"
+    assert "^1.4.0"
     browser-pack "^6.0.1"
     browser-resolve "^1.11.0"
     browserify-zlib "~0.1.2"
@@ -702,7 +708,7 @@ browserify@^13.1.1:
     domain-browser "~1.1.0"
     duplexer2 "~0.1.2"
     events "~1.1.0"
-    glob "^5.0.15"
+    glob "^7.1.0"
     has "^1.0.0"
     htmlescape "^1.1.0"
     https-browserify "~0.0.0"
@@ -720,7 +726,7 @@ browserify@^13.1.1:
     readable-stream "^2.0.2"
     resolve "^1.1.4"
     shasum "^1.0.0"
-    shell-quote "^1.4.3"
+    shell-quote "^1.6.1"
     stream-browserify "^2.0.0"
     stream-http "^2.0.0"
     string_decoder "~0.10.0"
@@ -1562,8 +1568,8 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.0.15.tgz#fa63f590f3c2ad91275e4972a6cea545fb0aae44"
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.0.17.tgz#8537f3f12272678765b4fd6528c0f1f66f8f4558"
   dependencies:
     nan "^2.3.0"
     node-pre-gyp "^0.6.29"
@@ -1657,7 +1663,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@5.x, glob@^5.0.15, glob@~5.0.0:
+glob@5.x, glob@~5.0.0:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -1678,7 +1684,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2527,7 +2533,11 @@ lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.13.x:
+lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@~4.13.x:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
 
@@ -2803,33 +2813,9 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
-northbrook@4.3.4:
+northbrook@4.3.4, northbrook@^4.1.4, northbrook@^4.2.3, northbrook@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/northbrook/-/northbrook-4.3.4.tgz#fed13a439368be2f584a647930dac0c2b4c80ff1"
-  dependencies:
-    "@typed/sequence" "^1.1.0"
-    "@types/findup-sync" "^0.3.29"
-    "@types/minimist" "^1.1.29"
-    "@types/mkdirp" "^0.3.29"
-    "@types/node" "^6.0.52"
-    "@types/ramda" "0.0.2"
-    "@types/semver" "^5.3.30"
-    app-module-path "^2.1.0"
-    findup-sync "^0.4.3"
-    mkdirp "^0.5.1"
-    ramda "^0.22.1"
-    reginn "^2.1.4"
-    semver "^5.3.0"
-    simple-spinner "0.0.5"
-    stdio-mock "^1.1.0"
-    ts-node "^1.7.2"
-    typed-colors "^1.0.0"
-    typed-figures "^1.0.0"
-    typed-prompts "^1.4.0"
-
-northbrook@^4.1.4, northbrook@^4.2.3, northbrook@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/northbrook/-/northbrook-4.3.3.tgz#cf9b874c70b6771856fca0b7f72985a9ae7968ba"
   dependencies:
     "@typed/sequence" "^1.1.0"
     "@types/findup-sync" "^0.3.29"
@@ -3495,7 +3481,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@^1.4.3:
+shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   dependencies:


### PR DESCRIPTION
The official types use commonjs exports which fail when using es2015 builds.
Fix by using @typed/i18next that provides seperate commonjs and es2015 builds.

AFFECTS: @motorcycle/i18n