### PR TITLE
chore(META): implement create plugin

### DIFF
--- a/.plugins/create.ts
+++ b/.plugins/create.ts
@@ -1,0 +1,102 @@
+import { EOL } from 'os';
+import { writeFileSync, openSync, closeSync } from 'fs';
+import { join } from 'path';
+import { command, alias, description, withCallback } from 'northbrook';
+import * as mkdirp from 'mkdirp';
+import { prompt, input } from 'typed-prompts';
+
+export const create =
+  command(alias('create'), description('Create a new managed package'));
+
+export { create as plugin };
+
+type Answers = { description: string, author: string };
+
+withCallback(create, function ({ args, directory }, io) {
+  if (!args[0])
+    return io.stderr.write(`A directory to create your new package was not specified`);
+
+  const packageName = args[0];
+  const packageDirectory = join(directory, packageName);
+
+  const testScript =
+    `nb tslint --only @motorcyle/${packageName} && nb mocha --only @motorcycle/${packageName}`;
+
+  const packageTemplate = (answers: Answers) =>
+`{
+  "name": "@motorcycle/${packageName}",
+  "version": "0.0.0",
+  "description": "${answers.description}",
+  "main": "lib/index.js",
+  "jsnext:main": "lib.es2015/index.js",
+  "module": "lib.es2015/index.js",
+  "typings": "lib.es2015/index.d.ts",
+  "files": [
+    "lib",
+    "lib.es2015"
+  ],
+  "scripts": {
+    "test": "${testScript}"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/motorcyclejs/motorcyclejs"
+  },
+  "author": "${answers.author}",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/motorcyclejs/motorcyclejs/issues"
+  },
+  "homepage": "https://github.com/motorcyclejs/motorcyclejs#readme"
+}
+`;
+
+  io.stdout.write(`Generating @motorcycle/${packageName}...`);
+
+  // create packageDirectory
+  mkdirp(packageDirectory, (err: any) => {
+    if (err) return io.stderr.write(err.message || err);
+
+    // ask some questions to help generate package.json
+    prompt<Answers>([
+      input('description', 'Please describe your new Motorcycle package:'),
+      input('author', 'Who is primarily authoring this package?'),
+    ]).then(answers => {
+
+      // create package.json
+      writeFileSync(
+        join(packageDirectory, 'package.json'),
+        packageTemplate(answers),
+        { encoding: 'utf8' },
+      );
+
+      // create empty .npmignore
+      touch(join(packageDirectory, '.npmignore'));
+
+      const srcDirectory = join(packageDirectory, 'src');
+
+      // create src directory
+      mkdirp(join(srcDirectory, 'src'), (error: any) => {
+        if (error) return io.stderr.write(error.message || error);
+
+        // create index.ts
+        writeFileSync(join(srcDirectory, 'index.ts'), `export * from './${packageName}';\n`);
+
+        // create initial file
+        writeFileSync(
+          join(srcDirectory, `${packageName}.ts`),
+          `export function ${packageName}() {}\n`,
+        );
+
+        // create initial test file
+        touch(join(srcDirectory, `${packageName}.test.ts`));
+
+        io.stdout.write(` complete!` + EOL);
+      });
+    });
+  });
+});
+
+function touch (filePath: string) {
+  return closeSync(openSync(filePath, 'w'));
+}

--- a/northbrook.ts
+++ b/northbrook.ts
@@ -20,6 +20,7 @@ const config: NorthbrookConfig =
       tsc,
       tslint,
       '.plugins/karma.ts',
+      '.plugins/create.ts',
     ],
 
     mocha: {

--- a/package.json
+++ b/package.json
@@ -57,10 +57,12 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
     "karma-typescript": "^2.1.5",
+    "mkdirp": "^0.5.1",
     "northbrook": "4.3.4",
     "sinon": "^1.17.6",
     "ts-node": "1.7.2",
     "tslint": "^4.2.0",
+    "typed-prompts": "^1.5.0",
     "typescript": "^2.1.4",
     "yarn": "^0.18.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,7 +3912,7 @@ typed-figures@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typed-figures/-/typed-figures-1.0.0.tgz#898932b2797b59532cfdf03f23ec2e2dc136126a"
 
-typed-prompts@^1.4.0:
+typed-prompts@^1.4.0, typed-prompts@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/typed-prompts/-/typed-prompts-1.5.0.tgz#ac5ad872d71bfdf3a8bbe8d84d382fea8e8e7ef2"
   dependencies:


### PR DESCRIPTION
Implements a simple northbrook `create` plugin that scaffolds a new motorcyclejs
package with very little effort and adheres to the standards in place.

