### PR TITLE
feat(dom): switch to dom component function

### DIFF
--- a/dom/README.md
+++ b/dom/README.md
@@ -17,15 +17,15 @@ used.
 
 # API
 
-- [`makeDomDriver`](#makeDomDriver)
+- [`makeDomComponent`](#makeDomComponent)
 - [`mockDomSource`](#mockDomSource)
 - [`h`](#h)
 - [`hasCssSelector`](#hasCssSelector)
 - [`API Wrappers`](#api-wrappers)
 
-### <a id="makeDomDriver"></a> `makeDomDriver(container, options)`
+### <a id="makeDomDriver"></a> `makeDomComponent(container, options): DomComponent`
 
-A factory for the DOM driver function.
+A factory for the DOM component function.
 
 Takes a `container` to define the target on the existing DOM which this
 driver will operate on, and an `options` object as the second argument. The
@@ -61,7 +61,8 @@ the app on the DOM.
 
 #### Return:
 
-*(Function)* the DOM driver function. The function expects a stream of VNode as input, and outputs the DOMSource object.
+*(Function)* the DOM component function. The function expects an object `DomSinks`
+and returns an object `DomSources`
 
 - - -
 
@@ -211,5 +212,20 @@ export interface DomSource {
   namespace(): Array<string>;
   isolateSource(source: DomSource, scope: string): DomSource;
   isolateSink(sink: Stream<VNode>, scope: string): Stream<VNode>;
+}
+```
+
+### `DomSinks`
+
+```typescript
+export interface DomSinks extends Sinks {
+  view$: Stream<VNode>;
+}
+```
+
+### `DomSources`
+```typescript
+export interface DomSources extends Sources {
+  dom: DomSource;
 }
 ```

--- a/dom/package.json
+++ b/dom/package.json
@@ -42,6 +42,6 @@
     "url": "git+https://github.com/motorcyclejs/dom.git"
   },
   "scripts": {
-    "test": "nb tslint -o @motorcycle/dom && nb karma -o @motorcycle/dom"
+    "test": "../node_modules/.bin/nb tslint -o @motorcycle/dom && ../node_modules/.bin/nb karma -o @motorcycle/dom"
   }
 }

--- a/dom/src/api-wrappers/elements.ts
+++ b/dom/src/api-wrappers/elements.ts
@@ -1,6 +1,6 @@
-import { Stream } from 'most';
 import { DomSource } from '../types';
+import { Stream } from 'most';
 
-export function elements(domSource: DomSource): Stream<Array<Element>> {
-  return domSource.elements();
+export function elements<T extends Element>(domSource: DomSource): Stream<Array<T>> {
+  return domSource.elements<T>();
 }

--- a/dom/src/api-wrappers/useCapture.ts
+++ b/dom/src/api-wrappers/useCapture.ts
@@ -1,6 +1,7 @@
+import { DomSource, EventsFnOptions, StandardEvents } from '../types';
+
 import { Stream } from 'most';
 import { VNode } from 'mostly-dom';
-import { DomSource, EventsFnOptions, StandardEvents } from '../types';
 
 export function useCapture(domSource: DomSource): DomSource {
   return {
@@ -8,8 +9,8 @@ export function useCapture(domSource: DomSource): DomSource {
       return domSource.select(cssSelector);
     },
 
-    elements() {
-      return domSource.elements();
+    elements<T extends Element>() {
+      return domSource.elements<T>();
     },
 
     events(eventType: StandardEvents) {

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -1,5 +1,5 @@
 export * from './types';
-export * from './makeDomDriver';
+export * from './makeDomComponent';
 export * from './mockDomSource';
 export * from './api-wrappers';
 export * from 'mostly-dom';

--- a/dom/src/makeDomComponent.ts
+++ b/dom/src/makeDomComponent.ts
@@ -1,3 +1,4 @@
+import { Component, Sinks, Sources } from '@motorcycle/run';
 import { ElementVNode, Module, VNode, elementToVNode, init } from 'mostly-dom';
 import { Stream, map, scan } from 'most';
 
@@ -6,13 +7,15 @@ import { MotorcycleDomSource } from './DomSources';
 import { hold } from 'most-subject';
 import { vNodeWrapper } from './vNodeWrapper';
 
-export interface DomSinks {
+export interface DomSinks extends Sinks {
   view$: Stream<VNode>;
 }
 
-export interface DomSources {
+export interface DomSources extends Sources {
   dom: DomSource;
 }
+
+export interface DomComponent extends Component<DomSources, DomSinks> {}
 
 export function makeDomComponent(
   rootElement: HTMLElement,

--- a/dom/test/integration/events.test.ts
+++ b/dom/test/integration/events.test.ts
@@ -1,29 +1,31 @@
-import * as assert from 'assert';
 import * as Motorcycle from '@motorcycle/run';
-import { div, h4, h3, h2, input, makeDomDriver } from '../../src';
+import * as assert from 'assert';
 import * as most from 'most';
+
+import { div, h2, h3, h4, input, makeDomComponent } from '../../src';
+
 import { createRenderTarget } from '../helpers/createRenderTarget';
 
 describe('DOMSource.events()', function () {
   it('should catch a basic click interaction Observable', function (done) {
     function app() {
       return {
-        DOM: most.of(h3('.myelementclass', 'Foobar')),
+        view$: most.of(h3('.myelementclass', 'Foobar')),
       };
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
-    sources.DOM.select('.myelementclass').events('click').observe((ev: Event) => {
+    sources.dom.select('.myelementclass').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Foobar');
       dispose();
       done();
     });
     // Make assertions
-    sources.DOM.select(':root').elements().skip(1).take(1).observe(function ([root]: HTMLElement[]) {
+    sources.dom.select(':root').elements().skip(1).take(1).observe(function ([root]: HTMLElement[]) {
       const myElement: any = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
@@ -38,15 +40,15 @@ describe('DOMSource.events()', function () {
   it('should setup click detection with events() after run() occurs', function (done) {
     function app() {
       return {
-        DOM: most.of(h3('.test2.myelementclass', 'Foobar')),
+        view$: most.of(h3('.test2.myelementclass', 'Foobar')),
       };
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
-    sources.DOM.select('.myelementclass').events('click').observe((ev: Event) => {
+    sources.dom.select('.myelementclass').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Foobar');
       dispose();
@@ -64,10 +66,10 @@ describe('DOMSource.events()', function () {
     }, 200);
   });
 
-  it('should setup click detection on a ready DOM element (e.g. from server)', function (done) {
+  it('should setup click detection on a ready dom element (e.g. from server)', function (done) {
     function app() {
       return {
-        DOM: most.never(),
+        view$: most.never(),
       };
     }
 
@@ -78,10 +80,10 @@ describe('DOMSource.events()', function () {
     containerElement.appendChild(headerElement);
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(containerElement)(sinks.DOM),
+      dom: makeDomComponent(containerElement)(sinks).dom,
     }));
 
-    sources.DOM.select('.myelementclass').events('click').observe((ev: Event) => {
+    sources.dom.select('.myelementclass').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Foobar');
       dispose();
@@ -99,26 +101,26 @@ describe('DOMSource.events()', function () {
     }, 200);
   });
 
-  it('should catch events using id of root element in DOM.select', function (done) {
+  it('should catch events using id of root element in dom.select', function (done) {
     function app() {
       return {
-        DOM: most.of(h3('.myelementclass', 'Foobar')),
+        view$: most.of(h3('.myelementclass', 'Foobar')),
       };
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget('parent-001'))(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget('parent-001'))(sinks).dom,
     }));
 
     // Make assertions
-    sources.DOM.select('#parent-001').events('click').observe((ev: Event) => {
+    sources.dom.select('#parent-001').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Foobar');
       dispose();
       done();
     });
 
-    sources.DOM.select(':root').elements().skip(1).take(1).observe(function ([root]: HTMLElement[]) {
+    sources.dom.select(':root').elements().skip(1).take(1).observe(function ([root]: HTMLElement[]) {
       const myElement: any = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
@@ -130,26 +132,26 @@ describe('DOMSource.events()', function () {
 
   });
 
-  it('should catch events using id of top element in DOM.select', function (done) {
+  it('should catch events using id of top element in dom.select', function (done) {
     function app() {
       return {
-        DOM: most.of(h3('#myElementId', 'Foobar')),
+        view$: most.of(h3('#myElementId', 'Foobar')),
       };
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget('parent-002'))(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget('parent-002'))(sinks).dom,
     }));
 
     // Make assertions
-    sources.DOM.select('#myElementId').events('click').observe((ev: Event) => {
+    sources.dom.select('#myElementId').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Foobar');
       dispose();
       done();
     });
 
-    sources.DOM.select(':root').elements().skip(1).take(1)
+    sources.dom.select(':root').elements().skip(1).take(1)
       .observe(function ([root]: HTMLElement[]) {
         const myElement: any = root.querySelector('#myElementId');
         assert.notStrictEqual(myElement, null);
@@ -165,25 +167,25 @@ describe('DOMSource.events()', function () {
   it('should catch interaction events without prior select()', function (done) {
     function app() {
       return {
-        DOM: most.of(div('.parent', [
+        view$: most.of(div('.parent', [
           h3('.myelementclass', 'Foobar'),
         ])),
       };
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
     // Make assertions
-    sources.DOM.events('click').observe((ev: Event) => {
+    sources.dom.events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Foobar');
       dispose();
       done();
     });
 
-    sources.DOM.select(':root').elements().skip(1).take(1).observe(function ([root]: HTMLElement[]) {
+    sources.dom.select(':root').elements().skip(1).take(1).observe(function ([root]: HTMLElement[]) {
       const myElement: any = root.querySelector('.myelementclass');
       assert.notStrictEqual(myElement, null);
       assert.notStrictEqual(typeof myElement, 'undefined');
@@ -195,10 +197,10 @@ describe('DOMSource.events()', function () {
 
   });
 
-  it('should catch user events using DOM.select().select().events()', function (done) {
+  it('should catch user events using dom.select().select().events()', function (done) {
     function app() {
       return {
-        DOM: most.of(
+        view$: most.of(
           h3('.top-most', [
             h2('.bar', 'Wrong'),
             div('.foo', [
@@ -210,18 +212,18 @@ describe('DOMSource.events()', function () {
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
     // Make assertions
-    sources.DOM.select('.foo').select('.bar').events('click').observe((ev: Event) => {
+    sources.dom.select('.foo').select('.bar').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Correct');
       dispose();
       done();
     });
 
-    sources.DOM.select(':root').elements().skip(1).take(1)
+    sources.dom.select(':root').elements().skip(1).take(1)
       .observe(function ([root]: HTMLElement[]) {
         const wrongElement: any = root.querySelector('.bar');
         const correctElement: any = root.querySelector('.foo .bar');
@@ -239,10 +241,10 @@ describe('DOMSource.events()', function () {
 
   });
 
-  it('should catch events from many elements using DOM.select().events()', function (done) {
+  it('should catch events from many elements using dom.select().events()', function (done) {
     function app() {
       return {
-        DOM: most.of(div('.parent', [
+        view$: most.of(div('.parent', [
           h4('.clickable.first', 'First'),
           h4('.clickable.second', 'Second'),
         ])),
@@ -250,17 +252,17 @@ describe('DOMSource.events()', function () {
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
     // Make assertions
-    sources.DOM.select('.clickable').events('click').take(1)
+    sources.dom.select('.clickable').events('click').take(1)
       .observe((ev: Event) => {
         assert.strictEqual(ev.type, 'click');
         assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'First');
       });
 
-    sources.DOM.select('.clickable').events('click').skip(1).take(1)
+    sources.dom.select('.clickable').events('click').skip(1).take(1)
       .observe((ev: Event) => {
         assert.strictEqual(ev.type, 'click');
         assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Second');
@@ -268,7 +270,7 @@ describe('DOMSource.events()', function () {
         done();
       });
 
-    sources.DOM.select(':root').elements().skip(1).take(1)
+    sources.dom.select(':root').elements().skip(1).take(1)
       .observe(function ([root]: HTMLElement[]) {
         const firstElem: any = root.querySelector('.first');
         const secondElem: any = root.querySelector('.second');
@@ -287,7 +289,7 @@ describe('DOMSource.events()', function () {
   it('should catch interaction events from future elements', function (done) {
     function app() {
       return {
-        DOM: most.concat(
+        view$: most.concat(
           most.of(h2('.blesh', 'Blesh')),
           most.of(h3('.blish', 'Blish')).delay(100),
         ).concat(most.of(h4('.blosh', 'Blosh')).delay(100)),
@@ -295,11 +297,11 @@ describe('DOMSource.events()', function () {
     }
 
     const { sources, dispose } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget('parent-002'))(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget('parent-002'))(sinks).dom,
     }));
 
     // Make assertions
-    sources.DOM.select('.blosh').events('click').observe((ev: Event) => {
+    sources.dom.select('.blosh').events('click').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual((ev.target as HTMLHeadElement).textContent, 'Blosh');
       dispose();
@@ -307,7 +309,7 @@ describe('DOMSource.events()', function () {
     })
     .catch(done);
 
-    sources.DOM.select(':root').elements().skip(3).take(1)
+    sources.dom.select(':root').elements().skip(3).take(1)
       .observe(function ([root]: HTMLElement[]) {
         const myElement: any = root.querySelector('.blosh');
         assert.notStrictEqual(myElement, null);
@@ -325,7 +327,7 @@ describe('DOMSource.events()', function () {
   it('should catch a non-bubbling click event with useCapture', function (done) {
     function app() {
       return {
-        DOM: most.of(div('.parent', [
+        view$: most.of(div('.parent', [
           div('.clickable', 'Hello'),
         ])),
       };
@@ -345,10 +347,10 @@ describe('DOMSource.events()', function () {
     }
 
     const { sources } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
-    sources.DOM.select('.clickable').events('click', {useCapture: true})
+    sources.dom.select('.clickable').events('click', {useCapture: true})
       .observe((ev: Event) => {
         assert.strictEqual(ev.type, 'click');
         assert.strictEqual((ev.target as HTMLElement).tagName, 'DIV');
@@ -357,10 +359,10 @@ describe('DOMSource.events()', function () {
         done();
       });
 
-    sources.DOM.select('.clickable').events('click', {useCapture: false})
+    sources.dom.select('.clickable').events('click', {useCapture: false})
       .observe(assert.fail);
 
-    sources.DOM.select(':root').elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
+    sources.dom.select(':root').elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
       const clickable: any = root.querySelector('.clickable');
       setTimeout(() => click(clickable));
     });
@@ -372,7 +374,7 @@ describe('DOMSource.events()', function () {
 
     function app() {
       return {
-        DOM: most.of(div('.parent', [
+        view$: most.of(div('.parent', [
           input('.correct', { type: 'text' }, []),
           input('.wrong', { type: 'text' }, []),
           input('.dummy', { type: 'text' }),
@@ -381,17 +383,17 @@ describe('DOMSource.events()', function () {
     }
 
     const { sources } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
-    sources.DOM.select('.correct').events('blur', {useCapture: true})
+    sources.dom.select('.correct').events('blur', {useCapture: true})
       .observe((ev: Event) => {
         assert.strictEqual(ev.type, 'blur');
         assert.strictEqual((ev.target as HTMLElement).className, 'correct');
         done();
       });
 
-    sources.DOM.select(':root').elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
+    sources.dom.select(':root').elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
       const correct: any = root.querySelector('.correct');
       const wrong: any = root.querySelector('.wrong');
       const dummy: any = root.querySelector('.dummy');
@@ -408,7 +410,7 @@ describe('DOMSource.events()', function () {
 
     function app() {
       return {
-        DOM: most.of(div('.parent', [
+        view$: most.of(div('.parent', [
           input('.correct', { type: 'text' }, []),
           input('.wrong', { type: 'text' }, []),
           input('.dummy', { type: 'text' }),
@@ -417,17 +419,17 @@ describe('DOMSource.events()', function () {
     }
 
     const { sources } = Motorcycle.run<any, any>(app, (sinks: any) => ({
-      DOM: makeDomDriver(createRenderTarget())(sinks.DOM),
+      dom: makeDomComponent(createRenderTarget())(sinks).dom,
     }));
 
-    sources.DOM.select('.correct').events('blur')
+    sources.dom.select('.correct').events('blur')
       .observe((ev: Event) => {
         assert.strictEqual(ev.type, 'blur');
         assert.strictEqual((ev.target as HTMLElement).className, 'correct');
         done();
       });
 
-    sources.DOM.select(':root').elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
+    sources.dom.select(':root').elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
       const correct: any = root.querySelector('.correct');
       const wrong: any = root.querySelector('.wrong');
       const dummy: any = root.querySelector('.dummy');

--- a/dom/test/integration/isolation.test.ts
+++ b/dom/test/integration/isolation.test.ts
@@ -1,19 +1,20 @@
-import * as assert from 'assert';
 import * as Motorcycle from '@motorcycle/run';
-import { h, svg, div, span, h2, h3, h4, button, makeDomDriver, VNode, DomSource } from '../../src';
-import isolate from '@cycle/isolate';
+import * as assert from 'assert';
 import * as most from 'most';
-import { sync, hold } from 'most-subject';
+
+import { DomSource, VNode, button, div, h, h2, h3, h4, makeDomComponent, span, svg } from '../../src';
+import { hold, sync } from 'most-subject';
+
 import { createRenderTarget } from '../helpers/createRenderTarget';
 import { interval } from '../helpers/interval';
+import isolate from '@cycle/isolate';
 
-function effects (drivers: any) {
-  return function (sinks: any) {
-    return Object.keys(drivers).reduce((sources: any, driverKey: string) => {
-      sources[driverKey] = drivers[driverKey](sinks[driverKey]);
-      return sources;
-    }, {});
-  };
+function effects (sinks) {
+  const view$ = sinks.DOM || sinks.view$;
+
+  const { dom } = makeDomComponent(createRenderTarget())({ view$ });
+
+  return { DOM: dom };
 }
 
 describe('isolateSource', function () {
@@ -31,9 +32,7 @@ describe('isolateSource', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
 
@@ -60,9 +59,8 @@ describe('isolateSource', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
+
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'top-most');
     // Make assertions
     assert.strictEqual(typeof isolatedDOMSource.isolateSource, 'function');
@@ -84,9 +82,7 @@ describe('isolateSink', function () {
       };
     }
 
-    const { sinks, dispose } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sinks, dispose } = Motorcycle.run<any, any>(app, effects);
 
     // Make assertions
     sinks.DOM.take(1).observe(function (vtree: VNode) {
@@ -130,9 +126,7 @@ describe('isolateSink', function () {
       };
     }
 
-    const { sinks, dispose } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sinks, dispose } = Motorcycle.run<any, any>(app, effects);
 
     // Make assertions
     sinks.DOM.skip(2).take(1).observe(function (vtree: VNode) {
@@ -170,9 +164,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
     sources.DOM.select('.bar').elements().skip(1).take(1).observe(function (elements: HTMLElement[]) {
       assert.strictEqual(Array.isArray(elements), true);
@@ -220,9 +212,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sinks } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sinks } = Motorcycle.run<any, any>(app, effects);
 
     sinks.island.skip(1).take(1).observe(function (elements: HTMLElement[]) {
       assert.strictEqual(Array.isArray(elements), true);
@@ -255,9 +245,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
     const {isolateSource} = sources.DOM;
 
@@ -312,9 +300,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sinks } = Motorcycle.run<any, any>(IsolatedApp, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sinks } = Motorcycle.run<any, any>(IsolatedApp, effects);
 
     // Make assertions
     sinks.triangleElement.skip(1).take(1).observe((elements: HTMLElement[]) => {
@@ -351,9 +337,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources } = Motorcycle.run<any, any>(app, effects);
 
     const {isolateSource} = sources.DOM;
 
@@ -396,9 +380,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources } = Motorcycle.run<any, any>(app, effects);
 
     const {isolateSource} = sources.DOM;
 
@@ -426,9 +408,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources } = Motorcycle.run<any, any>(app, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources } = Motorcycle.run<any, any>(app, effects);
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
 
     // Make assertions
@@ -468,9 +448,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(main, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(main, effects);
 
     const topDOMSource = sources.DOM.isolateSource(sources.DOM, 'top');
     const fooDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
@@ -548,9 +526,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(main, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(main, effects);
 
     sources.DOM.select(':root').elements().skip(2).take(1).observe(function ([root]: HTMLElement[]) {
       const parentEl = root.querySelector('.parent') as HTMLElement;
@@ -595,9 +571,7 @@ describe('isolation', function () {
       };
     }
 
-    const { sources, dispose } = Motorcycle.run<any, any>(main, effects({
-      DOM: makeDomDriver(createRenderTarget()),
-    }));
+    const { sources, dispose } = Motorcycle.run<any, any>(main, effects);
 
     sources.DOM.select(':root').elements().skip(1).observe(function ([root]: HTMLElement[]) {
       setTimeout(() => {
@@ -646,9 +620,7 @@ describe('isolation', function () {
         return isolate(main)(sources);
       }
 
-      const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-        DOM: makeDomDriver(createRenderTarget()),
-      }));
+      const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
       sources.DOM.elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
         const element: any = root.querySelector('.btn');
@@ -690,9 +662,7 @@ describe('isolation', function () {
         return isolate(main)(sources);
       }
 
-      const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-        DOM: makeDomDriver(createRenderTarget()),
-      }));
+      const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
       sources.DOM.elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
         const element: any = root.querySelector('.btn');
@@ -735,9 +705,7 @@ describe('isolation', function () {
         return isolate(main, 'foo')(sources);
       }
 
-      const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-        DOM: makeDomDriver(createRenderTarget()),
-      }));
+      const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
       sources.DOM.elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
         const element: any = root.querySelector('.btn');
@@ -780,9 +748,7 @@ describe('isolation', function () {
         return isolate(main, 'foo')(sources);
       }
 
-      const { sources, dispose } = Motorcycle.run<any, any>(app, effects({
-        DOM: makeDomDriver(createRenderTarget()),
-      }));
+      const { sources, dispose } = Motorcycle.run<any, any>(app, effects);
 
       sources.DOM.elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
         const element: any = root.querySelector('.btn');
@@ -833,9 +799,7 @@ describe('isolation', function () {
         return { DOM: vdom$ };
       }
 
-      const { sources, dispose } = Motorcycle.run<any, any>(main, effects({
-        DOM: makeDomDriver(createRenderTarget()),
-      }));
+      const { sources, dispose } = Motorcycle.run<any, any>(main, effects);
 
       sources.DOM.elements().skip(1).take(1).observe(([root]: HTMLElement[]) => {
         const components = root.querySelectorAll('.btn');

--- a/dom/test/integration/issue-105.test.ts
+++ b/dom/test/integration/issue-105.test.ts
@@ -1,24 +1,16 @@
-import { run } from '@motorcycle/run';
-import { makeDomDriver, button, div } from '../../src';
-import { just } from 'most';
-import isolate from '@cycle/isolate';
 import * as assert from 'assert';
 
-function effects (drivers: any) {
-  return function (sinks: any) {
-    return Object.keys(drivers).reduce((sources: any, driverKey: string) => {
-      sources[driverKey] = drivers[driverKey](sinks[driverKey]);
-      return sources;
-    }, {});
-  };
-}
+import { button, div, makeDomComponent } from '../../src';
+
+import isolate from '@cycle/isolate';
+import { just } from 'most';
+import { run } from '@motorcycle/run';
 
 // TESTS
 describe('issue 105', () => {
   it('should only emit a single event with useCapture false', (done) => {
-    const { sources, sinks }: any = run<any, any>(withUseCaptureFalse, effects({
-      dom: makeDomDriver(document.createElement('div')),
-    }));
+    const { sources, sinks }: any =
+      run<any, any>(withUseCaptureFalse, makeDomComponent(document.createElement('div')));
 
     sources.dom.elements().skip(1).take(1).observe(([root]: Element[]) => {
       const button = root.querySelector('button');
@@ -36,9 +28,8 @@ describe('issue 105', () => {
   });
 
   it('should only emit a single event with useCapture true', (done) => {
-    const { sources, sinks }: any = run<any, any>(withUseCaptureTrue, effects({
-      dom: makeDomDriver(document.createElement('div')),
-    }));
+    const { sources, sinks }: any =
+      run<any, any>(withUseCaptureTrue, makeDomComponent(document.createElement('div')));
 
     sources.dom.elements().skip(1).take(1).observe(([root]: Element[]) => {
       const button = root.querySelector('button');
@@ -78,7 +69,7 @@ function withUseCaptureFalse (sources: any) {
   const aHeader = augmentComponent(Header, { aButtonToggle$ })(aHeaderSources);
 
   return {
-    dom: aHeader.dom,
+    view$: aHeader.dom,
     toggle$: aButtonToggle$,
   };
 }
@@ -105,7 +96,7 @@ function withUseCaptureTrue (sources: any) {
   const aHeader = augmentComponent(Header, { aButtonToggle$ })(aHeaderSources);
 
   return {
-    dom: aHeader.dom,
+    view$: aHeader.dom,
     toggle$: aButtonToggle$,
   };
 }

--- a/dom/test/integration/rendering.test.ts
+++ b/dom/test/integration/rendering.test.ts
@@ -1,20 +1,21 @@
 import * as assert from 'assert';
+
+import { DomSource, VNode, a, div, h2, makeDomComponent, p } from '../../src';
+import { Object, run } from '@motorcycle/run';
 import { Stream, just } from 'most';
-import { makeDomDriver, div, h2, a, p, DomSource, VNode } from '../../src';
-import { run, Object } from '@motorcycle/run';
 
 interface DomSources {
   dom: DomSource;
 }
 
 interface DomSinks extends Object<any> {
-  dom: Stream<VNode>;
+  view$: Stream<VNode>;
 }
 
 describe('rendering', () => {
   it('patches text nodes initially present on rootElement', (done) => {
     function main() {
-      const dom = just(
+      const view$ = just(
         div('#page', {}, [
           h2('Home'),
           div({}, [
@@ -26,12 +27,10 @@ describe('rendering', () => {
         ]),
       );
 
-      return { dom };
+      return { view$ };
     }
 
-    const { sources, dispose } = run<DomSources, DomSinks>(main, (sinks: DomSinks) => ({
-      dom: makeDomDriver(createInitialRenderTarget())(sinks.dom),
-    }));
+    const { sources, dispose } = run<DomSources, DomSinks>(main, makeDomComponent(createInitialRenderTarget()));
 
     sources.dom.elements().skip(1).take(1)
       .observe(elements => {


### PR DESCRIPTION
Changes the `makeDomDriver` to `makeDomComponent` which now returns a component function with the following type signature.

```typescript
interface DomSinks {
  view$: Stream<VNode>;
}

interface DomSources {
  dom: DomSource;
}

function Dom(sinks: DomSinks): DomSources;
```