### PR TITLE
fix(isolateDom): generate scope key before calling component

### DIFF
--- a/dom/src/isolateDom.test.ts
+++ b/dom/src/isolateDom.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+
+import { DomSinks, DomSources, makeDomComponent } from './makeDomComponent';
+
+import { MotorcycleDomSource } from './DomSources';
+import { div } from 'mostly-dom';
+import { isolateDom } from './isolateDom';
+import { just } from 'most';
+import { run } from '@motorcycle/run';
+
+const testElement = document.createElement('div');
+
+describe(`isolateDom`, () => {
+  it(`accepts an isolation scope `, (done) => {
+    const scope = `foo`;
+
+    function testComponent(sources: DomSources): DomSinks {
+      const namespace = sources.dom.namespace();
+
+      return { view$: just(div()) };
+    }
+
+    const dom = new MotorcycleDomSource(just(testElement), []);
+
+    const isolatedComponent = isolateDom(testComponent, scope);
+
+    isolatedComponent({ dom }).view$.observe((view) => {
+      assert.ok(view.scope && view.scope.indexOf(scope) > -1);
+      done();
+    });
+  });
+});

--- a/dom/src/isolateDom.ts
+++ b/dom/src/isolateDom.ts
@@ -3,12 +3,11 @@ import { DomSinks, DomSource, DomSources } from './';
 import { Component } from '@motorcycle/run';
 
 export function isolateDom<Sources extends DomSources, Sinks extends DomSinks>(
-  ComponentFn: Component<Sources, Sinks>): Component<Sources, Sinks>
+  ComponentFn: Component<Sources, Sinks>,
+  key = createKey()): Component<Sources, Sinks>
 {
   return function (sources: Sources): Sinks {
     const { dom } = sources;
-
-    const key: string = createKey();
 
     const isolatedDom: DomSource = dom.isolateSource(dom, key);
 


### PR DESCRIPTION
Generating a key when calling the isolated component can lead to
inconsistent behavior, and errors when trying to patch the dom.

AFFECTS: @motorcycle/dom

BREAKING CHANGES: generate scope when calling isolateDom

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] I added new tests for the issue I fixed or the feature I built
- [x] I ran `npm test` for the package I'm modifying
- [ ] I used `npm run commit` instead of `git commit`