### PR TITLE
chore(META): remove auto-deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,3 @@ before_install:
 script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - npm run test:ci
-
-after_success:
-  bash .scripts/deploy.sh

--- a/dom/package.json
+++ b/dom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@motorcycle/dom",
   "description": "Standard DOM Driver for Motorcycle.js",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "author": "Tylor Steinberger <tlsteinberger167@gmail.com>",
   "main": "lib/index.js",
   "module": "lib.es2015/index.js",


### PR DESCRIPTION
There have been some errors regarding the automatic deployment script in the past, in the future we will no longer use Northbrook, and all releases will be handled manually.